### PR TITLE
Fixed News Title Localisation

### DIFF
--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,0 +1,28 @@
+---
+layout: default
+---
+<!-- page.html -->
+        <div class="post">
+
+          <header class="post-header">
+            <h1 class="post-title">{% t page.title %}</h1>
+            <p class="post-meta">{% include date_format.html format="long" date_from=page %}{%- if page.author -%} • {{ page.author }}{%- endif -%}{%- if page.meta -%} • {{ page.meta }}{%- endif -%}</p>
+            <p class="post-tags">
+      <a href="{{ year | prepend: '/blog/' | prepend: site.baseurl}}"> <i class="fas fa-calendar fa-sm"></i> {{ year }} </a>
+
+    </p>
+          </header>
+
+          <article>
+            {{ content }}
+          </article>
+
+          {%- if page.related_publications != null and page.related_publications.size > 0 -%}
+          {% assign publications = page.related_publications | replace: ", ", "," | split: "," | join: "|" %}
+          <h2>References</h2>
+          <div class="publications">
+            {% bibliography -f {{ site.scholar.bibliography }} -q @*[key^={{ publications }}]* %}
+          </div>
+          {%- endif %}
+
+        </div>

--- a/_news/announcement_1.md
+++ b/_news/announcement_1.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 title: news.titles.news1
 date: 2015-10-22 15:59:00-0400
 inline: true

--- a/_news/announcement_2.md
+++ b/_news/announcement_2.md
@@ -1,11 +1,9 @@
 ---
-layout: post
+layout: news
 title: news.titles.news2
 date: 2015-11-07 16:11:00-0400
 inline: false
 related_posts: false
 ---
-
-<!-- FIXME title not being localized when visualizing announcement -->
 
 {% translate_file _news/announcement_2.md %}

--- a/_news/announcement_3.md
+++ b/_news/announcement_3.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: news
 title: news.titles.news3
 date: 2016-01-15 07:59:00-0400
 inline: true


### PR DESCRIPTION
Added  modified variant of the _page_ layout named _news_ and converted all news to the _news_ layout. Functionally equivalent to currently displayed news with the exception of working title localization.