### PR TITLE
General date format for languages without specific date format

### DIFF
--- a/_includes/date_format.html
+++ b/_includes/date_format.html
@@ -12,4 +12,6 @@ Here, add language specific date formats
 {% t month %} {{day}}, {{year}}
 {% elsif site.lang == 'pt-br' %}
 {{day}} de {% t month %}, {{year}}
+{% else %}
+{{day}} {% t month %} {{year}}
 {% endif %}


### PR DESCRIPTION
So far, no date is displayed if the language is neither `en` nor `pt-br`. This adds a catch-all else-condition to the most standard date format (`DD month YYYY`).