### PR TITLE
Fix code scanning alert no. 8: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/_plugins/download-3rd-party.rb
+++ b/_plugins/download-3rd-party.rb
@@ -3,7 +3,7 @@ Jekyll::Hooks.register :site, :after_init do |site|
   require 'digest'
   require 'fileutils'
   require 'nokogiri'
-  require 'open-uri'
+  require 'net/http'
   require 'uri'
 
   font_file_types = ['otf', 'ttf', 'woff', 'woff2']
@@ -69,10 +69,14 @@ Jekyll::Hooks.register :site, :after_init do |site|
     # download the file if it doesn't exist
     unless File.file?(dest)
       puts "Downloading #{url} to #{dest}"
-      File.open(dest, "wb") do |saved_file|
-        URI.open(url, "rb") do |read_file|
-          saved_file.write(read_file.read)
+      uri = URI.parse(url)
+      response = Net::HTTP.get_response(uri)
+      if response.is_a?(Net::HTTPSuccess)
+        File.open(dest, "wb") do |saved_file|
+          saved_file.write(response.body)
         end
+      else
+        raise "Failed to download #{url} to #{dest}: #{response.message}"
       end
 
       # check if the file was downloaded successfully


### PR DESCRIPTION
Fixes [https://github.com/george-gca/multi-language-al-folio/security/code-scanning/8](https://github.com/george-gca/multi-language-al-folio/security/code-scanning/8)

To fix the problem, we should replace the use of `URI.open` with a safer alternative that does not call `Kernel.open` internally. Specifically, we can use `Net::HTTP` to perform the HTTP request and read the file content. This approach avoids the security risks associated with `URI.open`.

1. Replace the `URI.open` call with `Net::HTTP` to fetch the content of the URL.
2. Update the `download_file` method to use `Net::HTTP` for downloading the file.
3. Ensure that the new implementation maintains the existing functionality of downloading the file and saving it to the specified destination.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
