### PR TITLE
Fix code scanning alert no. 10: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/_plugins/download-3rd-party.rb
+++ b/_plugins/download-3rd-party.rb
@@ -148,7 +148,7 @@ Jekyll::Hooks.register :site, :after_init do |site|
       puts "Downloading fonts from #{url} to #{dest}"
       # download the css file with a fake user agent to force downloading woff2 fonts instead of ttf
       # user agent from https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome
-      doc = Nokogiri::HTML(URI.open(url, "User-Agent" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"))
+      doc = Nokogiri::HTML(URI(url).open("User-Agent" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"))
       css = CssParser::Parser.new
       css.load_string! doc.document.text
 


### PR DESCRIPTION
Fixes [https://github.com/george-gca/multi-language-al-folio/security/code-scanning/10](https://github.com/george-gca/multi-language-al-folio/security/code-scanning/10)

To fix the problem, we need to replace the usage of `URI.open` with `URI(...).open`. This change ensures that the URL is parsed and validated by the `URI` class before being opened, which mitigates the risk of command injection. Specifically, we will modify the code on line 151 to use `URI(url).open` instead of `URI.open(url)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
