### PR TITLE
Fix code scanning alert no. 11: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/_plugins/download-3rd-party.rb
+++ b/_plugins/download-3rd-party.rb
@@ -92,7 +92,7 @@ Jekyll::Hooks.register :site, :after_init do |site|
     unless File.directory?(dest) && !Dir.empty?(dest)
       puts "Downloading fonts from #{url} to #{dest}"
       # get available fonts from the url
-      doc = Nokogiri::HTML(URI.open(url, "User-Agent" => "Ruby/#{RUBY_VERSION}"))
+      doc = Nokogiri::HTML(URI(url).open("User-Agent" => "Ruby/#{RUBY_VERSION}"))
       doc.css('a').each do |link|
         # get the file name from the url
         file_name = link['href'].split('/').last.split('?').first
@@ -116,7 +116,7 @@ Jekyll::Hooks.register :site, :after_init do |site|
     unless File.directory?(dest) && !Dir.empty?(dest)
       puts "Downloading images from #{url} to #{dest}"
       # get available fonts from the url
-      doc = Nokogiri::HTML(URI.open(url, "User-Agent" => "Ruby/#{RUBY_VERSION}"))
+      doc = Nokogiri::HTML(URI(url).open("User-Agent" => "Ruby/#{RUBY_VERSION}"))
       doc.xpath('/html/body/div/div[3]/table/tbody/tr/td[1]/a').each do |link|
         # get the file name from the url
         file_name = link['href'].split('/').last.split('?').first


### PR DESCRIPTION
Fixes [https://github.com/george-gca/multi-language-al-folio/security/code-scanning/11](https://github.com/george-gca/multi-language-al-folio/security/code-scanning/11)

To fix the problem, we will replace the use of `URI.open` with `URI(url).open`. This change ensures that the URL is parsed and validated before being opened, reducing the risk of command injection. We will make this change in the `download_fonts` and `download_images` methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
