### PR TITLE
Rewrite date_format in language groups, add support for the Chinese language

### DIFF
--- a/_includes/date_format.liquid
+++ b/_includes/date_format.liquid
@@ -9,16 +9,39 @@
   Here, add language specific date formats
 {% endcomment %}
 
-{%- if site.active_lang == 'en-us' -%}
-  {{ month }}
-  {{ day }}, {{ year }}
-{%- elsif site.active_lang == 'fr-ca' -%}
-  {{ day }}
-  {{ month }}, {{ year }}
-{%- elsif site.active_lang == 'pt-br' -%}
-  {{ day }} de {{ month }}, {{ year }}
-{%- else -%}
-  {{ day }}
-  {{ month }}
-  {{ year }}
-{%- endif -%}
+{% assign lang = site.active_lang | split: '-' | first %}
+{% assign lang_last = site.active_lang | split: '-' | last %}
+
+{% case lang %}
+  {% when 'en' %}
+    {% case lang_last %}
+      {% when 'us', 'uk' %}
+        {{ month }}
+        {{ day }}, {{ year }}
+    {% endcase %}
+
+  {% when 'fr' %}
+    {% case lang_last %}
+      {% when 'ca' %}
+        {{ day }}
+        {{ month }}, {{ year }}
+    {% endcase %}
+
+  {% when 'pt' %}
+    {% case lang_last %}
+      {% when 'br' %}
+        {{ day }} de {{ month }}, {{ year }}
+    {% endcase %}
+
+  {% when 'zh' %}
+    {% case lang_last %}
+      {% comment %} Simplified Chinese family {% endcomment %}
+      {% when 'cn', 'sg', 'my', 'hans' %} 
+        {{ year }}年{{ month }}月{{ day }}日
+      {% comment %} Traditional Chinese family {% endcomment %}
+      {% when 'tw', 'hk', 'mo', 'hant' %}
+        {{ year }}年{{ month }}月{{ day }}日
+    {% endcase %}
+
+    {% comment %} Add a new language using when... if needed {% endcomment %}
+{% endcase %}

--- a/_includes/related_posts.liquid
+++ b/_includes/related_posts.liquid
@@ -9,13 +9,11 @@
       <ul class="list-disc pl-8"></ul>
 
       <!-- Adds related posts to the end of an article -->
-      <h2 class="text-3xl font-semibold mb-4 mt-12">Enjoy Reading This Article?</h2>
+      <h2 class="text-3xl font-semibold mb-4 mt-12">{{ site.data[site.active_lang].strings.related_posts.title }}</h2>
     {% else %}
-      <h2 class="text-3xl font-semibold mb-4 mt-12">Enjoy Reading This Article?</h2>
+      <h2 class="text-3xl font-semibold mb-4 mt-12">{{ site.data[site.active_lang].strings.related_posts.title }}</h2>
     {% endif %}
 
-    <!-- Adds related posts to the end of an article -->
-    <h2 class="text-3xl font-semibold mb-4 mt-12">{{ site.data[site.active_lang].strings.related_posts.title }}</h2>
     <p class="mb-2">{{ site.data[site.active_lang].strings.related_posts.description }}</p>
   {% endunless %}
 


### PR DESCRIPTION
This is a minor fix. 
Following our discussion and fixes (https://github.com/alshedivat/al-folio/pull/3015) for the language support in `repo.liquid` and `repo_user.liquid` in the al-folio repository, I recently found that there is this `date_format.liquid` unique to `multi-language-al-folio`, which could use the same fix.

The date format shown under the Chinese language has fallen back to defaults since the beginning, which looked very weird. Given that there are so many branches of Chinese writing, I adopt and adapt the fixes (https://github.com/alshedivat/al-folio/pull/3015) here for **greater extensibility, especially for variants, without the need to write layers upon layers of ``elsif'**'.

The original en-us, pt-br, fr-ca are rewritten to align with this format.