### PR TITLE
Fix duplicated hard-coded lines of "Enjoy reading this article?"

### DIFF
--- a/_includes/related_posts.liquid
+++ b/_includes/related_posts.liquid
@@ -9,13 +9,11 @@
       <ul class="list-disc pl-8"></ul>
 
       <!-- Adds related posts to the end of an article -->
-      <h2 class="text-3xl font-semibold mb-4 mt-12">Enjoy Reading This Article?</h2>
+      <h2 class="text-3xl font-semibold mb-4 mt-12">{{ site.data[site.active_lang].strings.related_posts.title }}</h2>
     {% else %}
-      <h2 class="text-3xl font-semibold mb-4 mt-12">Enjoy Reading This Article?</h2>
+      <h2 class="text-3xl font-semibold mb-4 mt-12">{{ site.data[site.active_lang].strings.related_posts.title }}</h2>
     {% endif %}
 
-    <!-- Adds related posts to the end of an article -->
-    <h2 class="text-3xl font-semibold mb-4 mt-12">{{ site.data[site.active_lang].strings.related_posts.title }}</h2>
     <p class="mb-2">{{ site.data[site.active_lang].strings.related_posts.description }}</p>
   {% endunless %}
 


### PR DESCRIPTION
This patch fixes https://github.com/george-gca/multi-language-al-folio/issues/57.

Since in the original `al-folio` project, the hard-coded "Enjoy reading this article?" lines are the same regardless of whether the page type is "post", here I also keep them the same. If further localization is needed differently, new patches can be based on the `else` block.